### PR TITLE
Release/0.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+## 0.2.1 (November 10, 2022)
+
+FEATURES:
+* Upgrade to Terraform 1.3.4 and above.
+* Upgrade to AzureRm provider 3.31.0 and above.
+
+ENHANCEMENTS:
+* Delete the deprecated version constraint in the azurerm provider.
+* Code formatting with IntelliJ and `terraform fmt -recursive`.
+* Add a Add a change log file.
+
+BUG FIXES:
+* Delete the deprecated option `resource_group_name`on the resources `azurerm_lb_backend_address_pool`, `azurerm_lb_probe` and `azurerm_lb_rule`.
+* Replace `backend_address_pool_id` with `backend_address_pool_ids`in the resource `azurerm_lb_rule`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ Test
 
 Requirement
 -----
-- Terraform v0.12.23 and above. 
+
+- Terraform v0.12.23 and above.
 - AzureRm provider version 2.1 and above.
 
 Terraform resources used within the module

--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Test
 Requirement
 -----
 
-- Terraform v0.12.23 and above.
-- AzureRm provider version 2.1 and above.
+- Terraform v1.3.4 and above.
+- AzureRm provider version 3.31.0 and above.
 
 Terraform resources used within the module
 -----

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ variables:
   - name: vmImageName
     value: "ubuntu-latest"
   - name: terraform_version
-    value: "0.12.26"
+    value: "1.3.4"
   - name: artifact_name
     value: Az-LoadBalancer
   - name: backend_and_main_secret_file_id

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -8,8 +8,8 @@ Create the following objects : 1 vnet/subnet with 2 Internal LB, 2 LB rules with
 
 -----
 
-- Terraform v0.12.23 and above.
-- AzureRm provider version 2.1 and above.
+- Terraform v1.3.4 and above.
+- AzureRm provider version 3.31.0 and above.
 
 Usage
 -----

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -7,7 +7,8 @@ Content
 Create the following objects : 1 vnet/subnet with 2 Internal LB, 2 LB rules with an Http probe.
 
 -----
-- Terraform v0.12.23 and above. 
+
+- Terraform v0.12.23 and above.
 - AzureRm provider version 2.1 and above.
 
 Usage

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -27,7 +27,6 @@ provider "azurerm" {
   subscription_id = var.subscription_id
   client_id       = var.client_id
   client_secret   = var.client_secret
-  version         = "~> 2.0"
   features {}
 }
 
@@ -139,7 +138,7 @@ resource "azurerm_virtual_network" "Demo" {
 
 module "Create-AzureRmLoadBalancer-Demo" {
   source                 = "JamesDLD/Az-LoadBalancer/azurerm"
-  version                = "0.2.0"
+  version                = "0.2.1"
   Lbs                    = var.Lbs
   lb_prefix              = "myproductlb-perimeter"
   lb_resource_group_name = data.azurerm_resource_group.rg.name

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -124,10 +124,10 @@ resource "azurerm_virtual_network" "Demo" {
 #Call module
 
 module "Create-AzureRmLoadBalancer-Demo" {
-  source = "../../"
+  #source = "../../"
   #source = "git::https://github.com/JamesDLD/terraform-azurerm-Az-LoadBalancer.git//?ref=master"
-  #source = "JamesDLD/Az-LoadBalancer/azurerm"
-  #version                     = "0.2.0"
+  source                 = "JamesDLD/Az-LoadBalancer/azurerm"
+  version                = "0.2.1"
   Lbs                    = var.Lbs
   lb_prefix              = "myproductlb-perimeter"
   lb_resource_group_name = data.azurerm_resource_group.rg.name

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -125,8 +125,8 @@ resource "azurerm_virtual_network" "Demo" {
 #Call module
 
 module "Create-AzureRmLoadBalancer-Demo" {
-  source = "git::https://github.com/JamesDLD/terraform-azurerm-Az-LoadBalancer.git//?ref=master"
-  #source = "../../"
+  source = "../../"
+  #source = "git::https://github.com/JamesDLD/terraform-azurerm-Az-LoadBalancer.git//?ref=master"
   #source = "JamesDLD/Az-LoadBalancer/azurerm"
   #version                     = "0.2.0"
   Lbs                    = var.Lbs

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -60,7 +60,7 @@ variable "Lbs" {
 variable "LbRules" {
   default = {
     lbrules1 = {
-      Id                = "1"   #Id of a the rule within the Load Balancer 
+      Id                = "1"   #Id of a the rule within the Load Balancer
       lb_key            = "lb1" #Key of the Load Balancer
       suffix_name       = "apa" #It must equals the Lbs suffix_name
       lb_port           = "80"
@@ -72,7 +72,7 @@ variable "LbRules" {
     }
 
     lbrules2 = {
-      Id                = "2"   #Id of a the rule within the Load Balancer 
+      Id                = "2"   #Id of a the rule within the Load Balancer
       lb_key            = "lb2" #Key of the Load Balancer
       suffix_name       = "iis" #It must equals the Lbs suffix_name
       lb_port           = "80"

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -14,7 +14,7 @@ provider "azurerm" {
   subscription_id = var.subscription_id
   client_id       = var.client_id
   client_secret   = var.client_secret
-  version         = "~> 2.0"
+  version         = "~> 3.31"
   features {}
 }
 

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -14,7 +14,6 @@ provider "azurerm" {
   subscription_id = var.subscription_id
   client_id       = var.client_id
   client_secret   = var.client_secret
-  version         = "~> 3.31"
   features {}
 }
 

--- a/main.tf
+++ b/main.tf
@@ -67,7 +67,9 @@ resource "azurerm_lb_rule" "lb_rule" {
   backend_address_pool_id = lookup(
     azurerm_lb_backend_address_pool.lb_backend,
     each.value["lb_key"],
-  )["id"]
+    )[
+    "id"
+  ]
   probe_id                = lookup(azurerm_lb_probe.lb_probe, each.key)["id"]
   load_distribution       = each.value["load_distribution"]
   idle_timeout_in_minutes = 4

--- a/main.tf
+++ b/main.tf
@@ -34,9 +34,8 @@ resource "azurerm_lb" "lb" {
 }
 
 resource "azurerm_lb_backend_address_pool" "lb_backend" {
-  for_each            = var.Lbs
-  resource_group_name = var.lb_resource_group_name
-  name                = "${var.lb_prefix}-${each.value["suffix_name"]}-bckpool1"
+  for_each = var.Lbs
+  name     = "${var.lb_prefix}-${each.value["suffix_name"]}-bckpool1"
 
   #This forces a destroy when adding a new lb --> loadbalancer_id     = lookup(azurerm_lb.lb, each.key)["id"]
   loadbalancer_id = "/subscriptions/${data.azurerm_subscription.current.subscription_id}/resourceGroups/${var.lb_resource_group_name}/providers/Microsoft.Network/loadBalancers/${var.lb_prefix}-${each.value["suffix_name"]}-lb${each.value["id"]}"
@@ -44,12 +43,11 @@ resource "azurerm_lb_backend_address_pool" "lb_backend" {
 }
 
 resource "azurerm_lb_probe" "lb_probe" {
-  for_each            = var.LbRules
-  resource_group_name = var.lb_resource_group_name
-  name                = "${var.lb_prefix}-${each.value["suffix_name"]}-probe${each.value["Id"]}"
-  port                = each.value["probe_port"]
-  protocol            = each.value["probe_protocol"]
-  request_path        = each.value["probe_protocol"] == "Tcp" ? "" : each.value["request_path"]
+  for_each     = var.LbRules
+  name         = "${var.lb_prefix}-${each.value["suffix_name"]}-probe${each.value["Id"]}"
+  port         = each.value["probe_port"]
+  protocol     = each.value["probe_protocol"]
+  request_path = each.value["probe_protocol"] == "Tcp" ? "" : each.value["request_path"]
 
   #This forces a destroy when adding a new lb --> loadbalancer_id     = lookup(azurerm_lb.lb, each.value["lb_key"])["id"]
   depends_on      = [azurerm_lb.lb]
@@ -58,21 +56,15 @@ resource "azurerm_lb_probe" "lb_probe" {
 
 resource "azurerm_lb_rule" "lb_rule" {
   for_each                       = var.LbRules
-  resource_group_name            = var.lb_resource_group_name
   name                           = "${var.lb_prefix}-${each.value["suffix_name"]}-rule${each.value["Id"]}"
   protocol                       = "Tcp"
   frontend_port                  = each.value["lb_port"]
   backend_port                   = each.value["backend_port"]
   frontend_ip_configuration_name = "${var.lb_prefix}-${each.value["suffix_name"]}-nic1-LBCFG"
-  backend_address_pool_id = lookup(
-    azurerm_lb_backend_address_pool.lb_backend,
-    each.value["lb_key"],
-    )[
-    "id"
-  ]
-  probe_id                = lookup(azurerm_lb_probe.lb_probe, each.key)["id"]
-  load_distribution       = each.value["load_distribution"]
-  idle_timeout_in_minutes = 4
+  backend_address_pool_ids       = [azurerm_lb_backend_address_pool.lb_backend[each.value.lb_key].id]
+  probe_id                       = lookup(azurerm_lb_probe.lb_probe, each.key)["id"]
+  load_distribution              = each.value["load_distribution"]
+  idle_timeout_in_minutes        = 4
 
   #This forces a destroy when adding a new lb --> loadbalancer_id     = lookup(azurerm_lb.lb, each.value["lb_key"])["id"]
   depends_on      = [azurerm_lb.lb]

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = ">= 0.12.6"
+  required_version = ">= 1.3.4"
 }


### PR DESCRIPTION
## 0.2.1 (November 10, 2022)

FEATURES:
* Upgrade to Terraform 1.3.4 and above.
* Upgrade to AzureRm provider 3.31.0 and above.

ENHANCEMENTS:
* Delete the deprecated version constraint in the azurerm provider.
* Code formatting with IntelliJ and `terraform fmt -recursive`.
* Add a Add a change log file.

BUG FIXES:
* Delete the deprecated option `resource_group_name`on the resources `azurerm_lb_backend_address_pool`, `azurerm_lb_probe` and `azurerm_lb_rule`.
* Replace `backend_address_pool_id` with `backend_address_pool_ids`in the resource `azurerm_lb_rule`.